### PR TITLE
Specify file encoding as UTF-8

### DIFF
--- a/joplin2obsidian/exporter.py
+++ b/joplin2obsidian/exporter.py
@@ -21,6 +21,9 @@ class Exporter:
             md_handler = MdHandler(md)
             dest_md = self.root_dir / md.relative_to(reader.dir)
             dest_md.parent.mkdir(parents=True, exist_ok=True)
-            with dest_md.open('w') as f:
+            # open() defaults to locale.getencoding(), which is cp1252 on
+            # windows for historical purposes. AFAIK, modern windows uses utf-8
+            # everywhere.
+            with dest_md.open('w', encoding="utf-8") as f:
                 for res_line in md_handler.replace_iter():
                     f.write(res_line)

--- a/joplin2obsidian/parser.py
+++ b/joplin2obsidian/parser.py
@@ -9,7 +9,9 @@ class MdHandler:
     
     
     def replace_iter(self):
-        with self.file_path.open('r') as f:
+        # open() defaults to locale.getencoding(), which is cp1252 on windows
+        # for historical purposes. AFAIK, modern windows uses utf-8 everywhere.
+        with self.file_path.open('r', encoding="utf-8") as f:
             for line in f.readlines():
                 yield self.src_re.sub(self._sub_group, line)
     


### PR DESCRIPTION
Windows will default to cp1252, even though all modern text editors use utf-8. This patch sets utf-8 for all platforms, on the assumption that it's benign on other OS. I'd be happy to modify it to a windows-only patch if desired.

Fixes #6 